### PR TITLE
Update VLLM Example sbatch files

### DIFF
--- a/frontier/sample_apps/vllm/launchmultinode_bb.sbatch
+++ b/frontier/sample_apps/vllm/launchmultinode_bb.sbatch
@@ -28,7 +28,7 @@ start=$SECONDS
 export HEAD_NODE_ADDR=$(hostname)
 echo "HEAD_NODE_ADDR: $HEAD_NODE_ADDR"
 
-APPTAINERENV_TRITON_CACHE_DIR="/tmp/triton/cache/"  # change write/build location for hip_utils in Triton
+export APPTAINERENV_TRITON_CACHE_DIR="/tmp/triton/cache/"  # change write/build location for hip_utils in Triton
 APPTAINER_CMD="apptainer exec --fakeroot --writable-tmpfs ./vllm_rocm.sif "
 export APPTAINER_BINDPATH=/mnt/bb
 

--- a/frontier/sample_apps/vllm/launchmultinode_bb.sbatch
+++ b/frontier/sample_apps/vllm/launchmultinode_bb.sbatch
@@ -28,6 +28,7 @@ start=$SECONDS
 export HEAD_NODE_ADDR=$(hostname)
 echo "HEAD_NODE_ADDR: $HEAD_NODE_ADDR"
 
+APPTAINERENV_TRITON_CACHE_DIR="/tmp/triton/cache/"  # change write/build location for hip_utils in Triton
 APPTAINER_CMD="apptainer exec --fakeroot --writable-tmpfs ./vllm_rocm.sif "
 export APPTAINER_BINDPATH=/mnt/bb
 

--- a/frontier/sample_apps/vllm/launchmultinode_lustre.sbatch
+++ b/frontier/sample_apps/vllm/launchmultinode_lustre.sbatch
@@ -14,7 +14,7 @@ start=$SECONDS
 export HEAD_NODE_ADDR=$(hostname)
 echo "HEAD_NODE_ADDR: $HEAD_NODE_ADDR"
 
-APPTAINERENV_TRITON_CACHE_DIR="/tmp/triton/cache/"  # change write/build location for hip_utils in Triton
+export APPTAINERENV_TRITON_CACHE_DIR="/tmp/triton/cache/"  # change write/build location for hip_utils in Triton
 APPTAINER_CMD="apptainer exec --fakeroot --writable-tmpfs ./vllm_rocm.sif "
 export APPTAINER_BINDPATH=/mnt/bb
 

--- a/frontier/sample_apps/vllm/launchmultinode_lustre.sbatch
+++ b/frontier/sample_apps/vllm/launchmultinode_lustre.sbatch
@@ -14,6 +14,7 @@ start=$SECONDS
 export HEAD_NODE_ADDR=$(hostname)
 echo "HEAD_NODE_ADDR: $HEAD_NODE_ADDR"
 
+APPTAINERENV_TRITON_CACHE_DIR="/tmp/triton/cache/"  # change write/build location for hip_utils in Triton
 APPTAINER_CMD="apptainer exec --fakeroot --writable-tmpfs ./vllm_rocm.sif "
 export APPTAINER_BINDPATH=/mnt/bb
 


### PR DESCRIPTION
## Problem Statement
Apptainer exec was failing because Triton cannot build its JIT Compiled dependencies.
See the following screenshot:

<img width="1347" height="216" alt="image" src="https://github.com/user-attachments/assets/148ed0a3-9cec-4cc9-9c2a-8d150c361f41" />

## Description
Triton is trying to build JIT dependencies. It fails to retrieve these dependencies because they cannot be written in the correct location (possible hashing issue?), or they cannot be written at all.

## Solution steps
* Provide Apptainer and Triton with a different cache location which is writable