### PR TITLE
Updating pytorch examples to use upstream aws-ofi-nccl

### DIFF
--- a/frontier/sample_apps/pytorch/amdrocmregistry/README.md
+++ b/frontier/sample_apps/pytorch/amdrocmregistry/README.md
@@ -1,6 +1,10 @@
 # Pytorch MNIST example using DistributedDataParallel
 
-Pytorch example borrowed from: [PrincetonUniversity/multi_gpu_training](https://github.com/PrincetonUniversity/multi_gpu_training/tree/main)
+Pytorch examples borrowed from: [PrincetonUniversity/multi_gpu_training](https://github.com/PrincetonUniversity/multi_gpu_training/tree/main)
+and from the OLCF docs.
+
+To switch between running the two available examples `./multinode_olcf_mnist_princeton_nompi4py.py`
+and `./microbench_olcf.py`, uncomment the appropriate line in the `pyrun.sh`.
 
 AMD maintains several ML and AI containers on DockerHub at https://hub.docker.com/u/rocm . Here we
 show how to run a Pytorch example using their Pytorch container.
@@ -11,7 +15,8 @@ To pull the pytorch container from the official ROCm container registry
 apptainer build pytorch_rocm642.sif docker://docker.io/rocm/pytorch:rocm6.4.2_ubuntu24.04_py3.12_pytorch_release_2.6.0
 ```
 
-Download the MNIST dataset first before submitting the job:
+Download the MNIST dataset first before submitting the job (not required if you are running
+`./microbench_olcf.py`):
 ```
 ./downloadmnist.sh
 ```
@@ -20,6 +25,10 @@ Submit the job with:
 ```
 sbatch submit.sbatch
 ```
+
+For better performance, you can build the [aws-ofi-nccl](https://github.com/aws/aws-ofi-nccl) library by running the
+`./awsofincclbuild.sh` script. There is an environment variable `APPTAINERENV_LD_LIBRARY_PATH` in
+the `submit.sbatch` that is set so that RCCL will be able to find and load the library during the Pytorch run.
 
 NOTE: This image is built by AMD and does not include MPI or matches any of the software provided by the
 Cray Programming Environment. OLCF has no control of what is included in the images, updates to the

--- a/frontier/sample_apps/pytorch/amdrocmregistry/awsofincclbuild.sh
+++ b/frontier/sample_apps/pytorch/amdrocmregistry/awsofincclbuild.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/bash -i
+module reset
+module load cpe/25.09
+module load rocm/6.4.2
+module load craype-accel-amd-gfx90a
+rocm_version=6.4.2
+git clone https://github.com/aws/aws-ofi-nccl
+cd aws-ofi-nccl
+git checkout 8dc2ce4
+libfabric_path=/opt/cray/libfabric/1.22.0
+export LD_LIBRARY_PATH=/opt/rocm-$rocm_version/lib:$LD_LIBRARY_PATH
+./autogen.sh
+CC=cc CFLAGS=-I/opt/rocm-$rocm_version/rccl/include ./configure \
+--with-libfabric=$libfabric_path --enable-trace \
+--prefix=$PWD --with-mpi=$MPICH_DIR --with-rocm=/opt/rocm-$rocm_version
+make
+make install

--- a/frontier/sample_apps/pytorch/amdrocmregistry/microbench_olcf.py
+++ b/frontier/sample_apps/pytorch/amdrocmregistry/microbench_olcf.py
@@ -1,0 +1,173 @@
+#microbench_olcf.py
+import torch
+import torchvision
+import time
+import argparse
+import os
+import copy
+import csv
+
+
+
+def forwardbackward(inp, optimizer, network, target, step=0, opt_step=1):
+    if step % opt_step == 0:
+        optimizer.zero_grad()
+
+    out = network(inp)
+    # If using HuggingFace model outputs logits, we need to extract them
+    if hasattr(out, 'logits'):
+        logits = out.logits
+    else:
+        logits = out
+    loss_fn = torch.nn.CrossEntropyLoss().to(device="cuda")
+
+    loss = loss_fn(logits, target)
+
+    loss.backward()
+    if (step + 1) % opt_step == 0:
+        optimizer.step()
+        optimizer.zero_grad()
+
+
+def run_benchmarking(local_rank, global_rank, world_size, params):
+    batch_size = params.batch_size
+    iterations = params.iterations
+
+    net = torchvision.models.resnet50
+    network = net().to(device="cuda")
+
+    param_copy = network.parameters()
+
+    ## MLPerf Setting
+    sgd_opt_base_learning_rate = 0.01
+    sgd_opt_weight_decay = 0.0001
+    sgd_opt_momentum = 0.9
+
+    optimizer = torch.optim.SGD(param_copy, lr = sgd_opt_base_learning_rate, momentum = sgd_opt_momentum, weight_decay=sgd_opt_weight_decay)
+
+    devices_to_run_on = [local_rank]
+    print (f"Rank {global_rank} running on device: {devices_to_run_on}")
+    network = torch.nn.parallel.DistributedDataParallel(network, device_ids=devices_to_run_on)
+    batch_size = int(batch_size / world_size)
+
+    inp = torch.randn(batch_size, 3, 224, 224, device="cuda")
+
+    # number of classes is 1000 for imagenet
+    target = torch.randint(0, 1000, (batch_size,), device="cuda")
+
+    forward_fn = forwardbackward
+    network.train()
+
+    ## warmup.
+    if global_rank == 0:
+        print (f"running forward and backward for warmup.")
+    for i in range(2):
+        forward_fn(inp, optimizer, network, target, step=0, opt_step=args.opt_step)
+
+    time.sleep(1)
+    torch.cuda.synchronize()
+
+    ## benchmark.
+    if global_rank == 0:
+        print (f"running the benchmark..")
+
+    tm = time.time()
+    with torch.autograd.profiler.emit_nvtx(enabled=False):
+        for i in range(iterations):
+            forward_fn(inp, optimizer, network, target, step=i, opt_step=args.opt_step)
+    torch.cuda.synchronize()
+
+    tm2 = time.time()
+    time_per_batch = (tm2 - tm) / iterations
+    throughput = batch_size / time_per_batch
+
+    dtype = 'FP32'
+
+    result = None
+    if not args.output_dir:
+        args.output_dir = "."
+
+    print (f"Rank {global_rank} finished: Mini batch size: {batch_size}, Throughput: {throughput}, Time per mini-batch: {time_per_batch}")
+
+
+    time_per_batch = torch.tensor([time_per_batch], dtype=torch.float32, device='cuda')
+    min_time = time_per_batch.clone().detach()
+    max_time = time_per_batch.clone().detach()
+    avg_time = time_per_batch.clone().detach()
+    throughput = torch.tensor([throughput], dtype=torch.float32, device='cuda')
+    tot_thru = throughput.clone().detach()
+    torch.distributed.reduce(min_time, dst=0, op=torch.distributed.ReduceOp.MIN)
+    torch.distributed.reduce(max_time, dst=0, op=torch.distributed.ReduceOp.MAX)
+    torch.distributed.reduce(avg_time, dst=0, op=torch.distributed.ReduceOp.SUM)
+    torch.distributed.reduce(throughput, dst=0, op=torch.distributed.ReduceOp.SUM)
+
+    time.sleep(3)
+    if global_rank == 0:
+        print ("")
+        print ("--------Overall Summary--------")
+        print (f"Num devices: {world_size}")
+        print (f"Dtype: {dtype}")
+        print (f"Mini batch size [img] : {batch_size*world_size}")
+        print (f"Mini batch size [img/gpu] : {batch_size}")
+        print (f"Total Throughput [img/sec] : {tot_thru.item()}")
+        print (f"Time per mini-batch [sec] : Min: {min_time.item()}, Max: {max_time.item()}, Avg: {avg_time.item()/world_size}")
+        result = {
+            "GPUs": world_size,
+            "Mini batch size [img]": batch_size * world_size,
+            "Mini batch size [img/gpu]": batch_size,
+            "Total Throughput [img/sec]": tot_thru,
+            "Min Time [sec]": min_time,
+            "Max Time [sec]": max_time,
+            "Avg Time [sec]": avg_time/world_size
+        }
+
+    csv_filename = f"{args.output_dir}/benchmark_summary.csv"
+    file_exists = os.path.isfile(csv_filename)
+    if result:
+        with open(csv_filename, "a", newline='') as csvfile:
+            writer = csv.writer(csvfile)
+            if not file_exists:
+                writer.writerow(result.keys())
+            writer.writerow(result.values())
+        print(f"Benchmark result saved to {csv_filename}")
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--batch-size" , type=int, required=False, default=64, help="Batch size (will be split among devices used by this invocation)")
+    parser.add_argument("--iterations", type=int, required=False, default=20, help="Iterations")
+    parser.add_argument("--opt-step", type=int, required=False, default=1, help="Optimizer update step")
+    parser.add_argument("--output-dir", type=str, default="", help="assign output directory name.")
+    parser.add_argument("--master_addr", type=str, required=True)
+    parser.add_argument("--master_port", type=str, required=True)
+
+    args = parser.parse_args()
+
+    num_gpus_per_rank = torch.cuda.device_count()
+
+    world_size = int(os.environ["SLURM_NTASKS"])
+    global_rank = rank = int(os.environ["SLURM_PROCID"])
+    local_rank = int(rank) % int(num_gpus_per_rank) # local_rank and device are 0 when using 1 GPU per task
+    backend = None
+    os.environ['WORLD_SIZE'] = str(world_size)
+    os.environ['RANK'] = str(global_rank)
+    os.environ['LOCAL_RANK'] = str(local_rank)
+    os.environ['MASTER_ADDR'] = str(args.master_addr)
+    os.environ['MASTER_PORT'] = str(args.master_port)
+    os.environ['NCCL_SOCKET_IFNAME'] = 'hsn0'
+
+    torch.distributed.init_process_group(
+        backend="nccl",
+        #init_method=f"tcp://{args.master_addr}:{args.master_port}",
+        init_method='env://',
+        rank=global_rank,
+        world_size=world_size,
+    )
+
+    print (f"Rank {global_rank} GPUs Visible: {num_gpus_per_rank}", flush=True)
+
+    torch.cuda.set_device(local_rank) # local_rank and device are 0 when using 1 GPU per task
+
+    run_benchmarking(local_rank,global_rank,world_size,copy.deepcopy(args))
+
+    torch.distributed.destroy_process_group()

--- a/frontier/sample_apps/pytorch/amdrocmregistry/pyrun.sh
+++ b/frontier/sample_apps/pytorch/amdrocmregistry/pyrun.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
-python3 -W ignore -u ./multinode_olcf_mnist_princeton_nompi4py.py --master_addr=$MASTER_ADDR --master_port=3442
+#python3 -W ignore -u ./multinode_olcf_mnist_princeton_nompi4py.py --master_addr=$MASTER_ADDR --master_port=3442
+python3 -W ignore -u ./microbench_olcf.py --master_addr=$MASTER_ADDR --master_port=3442

--- a/frontier/sample_apps/pytorch/amdrocmregistry/submit.sbatch
+++ b/frontier/sample_apps/pytorch/amdrocmregistry/submit.sbatch
@@ -5,10 +5,21 @@
 #SBATCH -t 00:05:00
 #SBATCH -p batch
 #SBATCH -q debug
-#SBATCH -N 2
+#SBATCH -N 4
 
 # Load modules
 module reset 
+module load cpe/25.09
+module load rocm/6.4.2
+
+module load olcf-container-tools
+module load apptainer-enable-mpi
+# If you want to use aws-ofi-rccl, then build it with the awsofircclbuild.sh script in this directory, and modify the below line to point to the aws-ofi-rccl/lib location
+export APPTAINERENV_LD_LIBRARY_PATH="${PWD}/aws-ofi-nccl/lib:$APPTAINERENV_LD_LIBRARY_PATH"
+##### see https://docs.olcf.ornl.gov/software/analytics/pytorch_frontier.html#aws-ofi-rccl-plugin
+export NCCL_NET_GDR_LEVEL=3           # Typically improves performance, but remove this setting if you encounter a hang/crash.
+export NCCL_CROSS_NIC=1               # On large systems, this NCCL setting has been found to improve performance
+export NCCL_SOCKET_IFNAME=hsn0        # NCCL/RCCL will use the high speed network to coordinate startup.
 
 # Get address of head node
 ips=`hostname -I`
@@ -25,4 +36,4 @@ mkdir -p ${MIOPEN_USER_DB_PATH}
 
 # Run script
 
-srun -N2 --tasks-per-node=8 -c7 --gpus-per-task=1 --gpu-bind=closest apptainer exec --workdir `pwd`  pytorch_rocm642.sif ./pyrun.sh
+srun -N4 --tasks-per-node=8 -c7 --gpus-per-task=1 --gpu-bind=closest apptainer exec --workdir `pwd`  pytorch_rocm642.sif ./pyrun.sh

--- a/frontier/sample_apps/pytorch/olcfbaseimage/README.md
+++ b/frontier/sample_apps/pytorch/olcfbaseimage/README.md
@@ -1,8 +1,12 @@
 # Pytorch MNIST example using DistributedDataParallel
 
-Example borrowed from: [PrincetonUniversity/multi_gpu_training](https://github.com/PrincetonUniversity/multi_gpu_training/tree/main)
+Pytorch examples borrowed from: [PrincetonUniversity/multi_gpu_training](https://github.com/PrincetonUniversity/multi_gpu_training/tree/main)
+and from the OLCF docs.
 
-to build container:
+To switch between running the two available examples `./multinode_olcf_mnist_princeton_nompi4py.py`
+and `./microbench_olcf.py`, uncomment the appropriate line in the `pyrun.sh`.
+
+To build container:
 ```
 apptainer build pytorch.sif pytorch.def
 ```
@@ -20,3 +24,6 @@ Submit the job with:
 sbatch submit.sbatch
 ```
 
+For better performance, you can build the [aws-ofi-nccl](https://github.com/aws/aws-ofi-nccl) library by running the
+`./awsofincclbuild.sh` script. There is an environment variable `APPTAINERENV_LD_LIBRARY_PATH` in
+the `submit.sbatch` that is set so that RCCL will be able to find and load the library during the Pytorch run.

--- a/frontier/sample_apps/pytorch/olcfbaseimage/awsofincclbuild.sh
+++ b/frontier/sample_apps/pytorch/olcfbaseimage/awsofincclbuild.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/bash -i
+module reset
+module load rocm/6.2.4
+module load craype-accel-amd-gfx90a
+
+#rocm_version=6.2.4
+#git clone --recursive https://github.com/ROCmSoftwarePlatform/aws-ofi-rccl
+#cd aws-ofi-rccl
+#libfabric_path=/opt/cray/libfabric/1.22.0
+#./autogen.sh
+#export LD_LIBRARY_PATH=/opt/rocm-$rocm_version/hip/lib:$LD_LIBRARY_PATH
+#CC=cc CFLAGS=-I/opt/rocm-$rocm_version/rccl/include ./configure \
+# --with-libfabric=$libfabric_path --with-rccl=/opt/rocm-$rocm_version --enable-trace \
+# --prefix=$PWD --with-hip=/opt/rocm-$rocm_version/hip --with-mpi=$MPICH_DIR
+#make
+#make install
+
+rocm_version=6.2.4
+git clone https://github.com/aws/aws-ofi-nccl
+cd aws-ofi-nccl
+git checkout 8dc2ce4
+libfabric_path=/opt/cray/libfabric/1.22.0
+export LD_LIBRARY_PATH=/opt/rocm-$rocm_version/lib:$LD_LIBRARY_PATH
+./autogen.sh
+CC=cc CFLAGS=-I/opt/rocm-$rocm_version/rccl/include ./configure \
+--with-libfabric=$libfabric_path --enable-trace \
+--prefix=$PWD --with-mpi=$MPICH_DIR --with-rocm=/opt/rocm-$rocm_version
+make
+make install

--- a/frontier/sample_apps/pytorch/olcfbaseimage/microbench_olcf.py
+++ b/frontier/sample_apps/pytorch/olcfbaseimage/microbench_olcf.py
@@ -1,0 +1,177 @@
+#microbench_olcf.py
+import torch
+import torchvision
+import time
+import argparse
+import os
+import copy
+import csv
+
+
+
+def forwardbackward(inp, optimizer, network, target, step=0, opt_step=1):
+    if step % opt_step == 0:
+        optimizer.zero_grad()
+
+    out = network(inp)
+    # If using HuggingFace model outputs logits, we need to extract them
+    if hasattr(out, 'logits'):
+        logits = out.logits
+    else:
+        logits = out
+    loss_fn = torch.nn.CrossEntropyLoss().to(device="cuda")
+
+    loss = loss_fn(logits, target)
+
+    loss.backward()
+    if (step + 1) % opt_step == 0:
+        optimizer.step()
+        optimizer.zero_grad()
+
+
+def run_benchmarking(local_rank, global_rank, world_size, params):
+    batch_size = params.batch_size
+    iterations = params.iterations
+
+    net = torchvision.models.resnet50
+    network = net().to(device="cuda")
+
+    param_copy = network.parameters()
+
+    ## MLPerf Setting
+    sgd_opt_base_learning_rate = 0.01
+    sgd_opt_weight_decay = 0.0001
+    sgd_opt_momentum = 0.9
+
+    optimizer = torch.optim.SGD(param_copy, lr = sgd_opt_base_learning_rate, momentum = sgd_opt_momentum, weight_decay=sgd_opt_weight_decay)
+
+    devices_to_run_on = [local_rank]
+    print (f"Rank {global_rank} running on device: {devices_to_run_on}")
+    network = torch.nn.parallel.DistributedDataParallel(network, device_ids=devices_to_run_on)
+    batch_size = int(batch_size / world_size)
+
+    inp = torch.randn(batch_size, 3, 224, 224, device="cuda")
+
+    # number of classes is 1000 for imagenet
+    target = torch.randint(0, 1000, (batch_size,), device="cuda")
+
+    forward_fn = forwardbackward
+    network.train()
+
+    ## warmup.
+    if global_rank == 0:
+        print (f"running forward and backward for warmup.")
+    for i in range(2):
+        forward_fn(inp, optimizer, network, target, step=0, opt_step=args.opt_step)
+
+    time.sleep(1)
+    torch.cuda.synchronize()
+
+    ## benchmark.
+    if global_rank == 0:
+        print (f"running the benchmark..")
+
+    tm = time.time()
+    with torch.autograd.profiler.emit_nvtx(enabled=False):
+        for i in range(iterations):
+            forward_fn(inp, optimizer, network, target, step=i, opt_step=args.opt_step)
+    torch.cuda.synchronize()
+
+    tm2 = time.time()
+    time_per_batch = (tm2 - tm) / iterations
+    throughput = batch_size / time_per_batch
+
+    dtype = 'FP32'
+
+    result = None
+    if not args.output_dir:
+        args.output_dir = "."
+
+    print (f"Rank {global_rank} finished: Mini batch size: {batch_size}, Throughput: {throughput}, Time per mini-batch: {time_per_batch}")
+
+    #min_time = comm.reduce(time_per_batch,op=MPI.MIN, root=0)
+    #max_time = comm.reduce(time_per_batch,op=MPI.MAX, root=0)
+    #avg_time = comm.reduce(time_per_batch,op=MPI.SUM, root=0) # prep for avg later
+    #tot_thru = comm.reduce(throughput,op=MPI.SUM, root=0)
+
+    time_per_batch = torch.tensor([time_per_batch], dtype=torch.float32, device='cuda')
+    min_time = time_per_batch.clone().detach()
+    max_time = time_per_batch.clone().detach()
+    avg_time = time_per_batch.clone().detach()
+    throughput = torch.tensor([throughput], dtype=torch.float32, device='cuda')
+    tot_thru = throughput.clone().detach()
+    torch.distributed.reduce(min_time, dst=0, op=torch.distributed.ReduceOp.MIN)
+    torch.distributed.reduce(max_time, dst=0, op=torch.distributed.ReduceOp.MAX)
+    torch.distributed.reduce(avg_time, dst=0, op=torch.distributed.ReduceOp.SUM)
+    torch.distributed.reduce(throughput, dst=0, op=torch.distributed.ReduceOp.SUM)
+
+    time.sleep(3)
+    if global_rank == 0:
+        print ("")
+        print ("--------Overall Summary--------")
+        print (f"Num devices: {world_size}")
+        print (f"Dtype: {dtype}")
+        print (f"Mini batch size [img] : {batch_size*world_size}")
+        print (f"Mini batch size [img/gpu] : {batch_size}")
+        print (f"Total Throughput [img/sec] : {tot_thru.item()}")
+        print (f"Time per mini-batch [sec] : Min: {min_time.item()}, Max: {max_time.item()}, Avg: {avg_time.item()/world_size}")
+        result = {
+            "GPUs": world_size,
+            "Mini batch size [img]": batch_size * world_size,
+            "Mini batch size [img/gpu]": batch_size,
+            "Total Throughput [img/sec]": tot_thru,
+            "Min Time [sec]": min_time,
+            "Max Time [sec]": max_time,
+            "Avg Time [sec]": avg_time/world_size
+        }
+
+    csv_filename = f"{args.output_dir}/benchmark_summary.csv"
+    file_exists = os.path.isfile(csv_filename)
+    if result:
+        with open(csv_filename, "a", newline='') as csvfile:
+            writer = csv.writer(csvfile)
+            if not file_exists:
+                writer.writerow(result.keys())
+            writer.writerow(result.values())
+        print(f"Benchmark result saved to {csv_filename}")
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--batch-size" , type=int, required=False, default=64, help="Batch size (will be split among devices used by this invocation)")
+    parser.add_argument("--iterations", type=int, required=False, default=20, help="Iterations")
+    parser.add_argument("--opt-step", type=int, required=False, default=1, help="Optimizer update step")
+    parser.add_argument("--output-dir", type=str, default="", help="assign output directory name.")
+    parser.add_argument("--master_addr", type=str, required=True)
+    parser.add_argument("--master_port", type=str, required=True)
+
+    args = parser.parse_args()
+
+    num_gpus_per_rank = torch.cuda.device_count()
+
+    world_size = int(os.environ["SLURM_NTASKS"])
+    global_rank = rank = int(os.environ["SLURM_PROCID"])
+    local_rank = int(rank) % int(num_gpus_per_rank) # local_rank and device are 0 when using 1 GPU per task
+    backend = None
+    os.environ['WORLD_SIZE'] = str(world_size)
+    os.environ['RANK'] = str(global_rank)
+    os.environ['LOCAL_RANK'] = str(local_rank)
+    os.environ['MASTER_ADDR'] = str(args.master_addr)
+    os.environ['MASTER_PORT'] = str(args.master_port)
+    os.environ['NCCL_SOCKET_IFNAME'] = 'hsn0'
+
+    torch.distributed.init_process_group(
+        backend="nccl",
+        #init_method=f"tcp://{args.master_addr}:{args.master_port}",
+        init_method='env://',
+        rank=global_rank,
+        world_size=world_size,
+    )
+
+    print (f"Rank {global_rank} GPUs Visible: {num_gpus_per_rank}", flush=True)
+
+    torch.cuda.set_device(local_rank) # local_rank and device are 0 when using 1 GPU per task
+
+    run_benchmarking(local_rank,global_rank,world_size,copy.deepcopy(args))
+
+    torch.distributed.destroy_process_group()

--- a/frontier/sample_apps/pytorch/olcfbaseimage/pyrun.sh
+++ b/frontier/sample_apps/pytorch/olcfbaseimage/pyrun.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
-python3 -W ignore -u ./multinode_olcf_mnist_princeton_nompi4py.py --master_addr=$MASTER_ADDR --master_port=3442
+#python3 -W ignore -u ./multinode_olcf_mnist_princeton_nompi4py.py --master_addr=$MASTER_ADDR --master_port=3442
+python3 -W ignore -u ./microbench_olcf.py --master_addr=$MASTER_ADDR --master_port=3442

--- a/frontier/sample_apps/pytorch/olcfbaseimage/submit.sbatch
+++ b/frontier/sample_apps/pytorch/olcfbaseimage/submit.sbatch
@@ -5,15 +5,25 @@
 #SBATCH -t 00:05:00
 #SBATCH -p batch
 #SBATCH -q debug
-#SBATCH -N 2
+#SBATCH -N 4
 
 # Load modules
 module reset 
+module load rocm/6.2.4
 module load olcf-container-tools
 module load apptainer-enable-mpi
-module load apptainer-enable-gpu
-module load craype-accel-amd-gfx90a
 
+
+
+## If you want to use aws-ofi-nccl, then build it with the awsofincclbuild.sh script in this directory, and modify the below line to point to the aws-ofi-nccl/lib location
+export APPTAINERENV_LD_LIBRARY_PATH="${PWD}/aws-ofi-nccl/lib:$APPTAINERENV_LD_LIBRARY_PATH"
+export APPTAINER_CONTAINLIBS=/usr/lib64/libhwloc.so.15
+# see https://docs.olcf.ornl.gov/software/analytics/pytorch_frontier.html#aws-ofi-rccl-plugin
+export NCCL_NET_GDR_LEVEL=3           # Typically improves performance, but remove this setting if you encounter a hang/crash.
+export NCCL_CROSS_NIC=1               # On large systems, this NCCL setting has been found to improve performance
+export NCCL_SOCKET_IFNAME=hsn0        # NCCL/RCCL will use the high speed network to coordinate startup.
+# uncomment this only if you need a lot of debug information
+#export NCCL_DEBUG=info
 
 # Get address of head node
 ips=`hostname -I`
@@ -29,4 +39,4 @@ mkdir -p ${MIOPEN_USER_DB_PATH}
 
 
 # Run script
-srun -N2 --label --tasks-per-node=8 -c7 --gpus-per-task=1 --gpu-bind=closest apptainer exec --workdir `pwd` --rocm pytorch.sif ./pyrun.sh
+srun -N4 --label --tasks-per-node=8 -c7 --gpus-per-task=1 --gpu-bind=closest apptainer exec --workdir `pwd` --rocm pytorch.sif ./pyrun.sh


### PR DESCRIPTION
- has been tested. There is a difference in performance with and without aws-ofi-nccl installed
- Using the upstream aws-ofi-nccl instead of ROCm's own aws-ofi-rccl since that is now deprecated. Upstream has ROCm support now and works well. There is no official release yet so the awsofincclbuild.sh script builds from a specific commit from the github repo.
- Added microbench_olcf.py to the pytorch example. This is taken from the OLCF docs. This has a summary of the performance, so I found it valuable to add. The example was modified to use Pytorch's own reduce implementation instead of using mpi4py's reduce. Saves us from adding an mpi4py dependency into the container (and dealing with the problems thereof).